### PR TITLE
fix: correct dot-lazy path resolution

### DIFF
--- a/.config/fish/functions/dot-commit-ai.fish
+++ b/.config/fish/functions/dot-commit-ai.fish
@@ -1,6 +1,13 @@
 function dot-commit-ai
     set -l commit_mode "staged"
     set -l diff_content ""
+    set -l copy_to_clipboard 0
+
+    for arg in $argv
+        if test "$arg" = "--clipboard"
+            set copy_to_clipboard 1
+        end
+    end
 
     # Check if there are staged changes
     if not dot diff --cached --quiet
@@ -39,6 +46,22 @@ function dot-commit-ai
 
     # Sanitize message (remove newlines if any, though prompt asks for single line)
     set commit_msg (string trim $commit_msg)
+
+    if test $copy_to_clipboard -eq 1
+        if command -v wl-copy > /dev/null
+            echo "$commit_msg" | wl-copy
+            echo "AI Commit message copied to clipboard!"
+            echo "Use 'c' in lazygit to paste and commit."
+        else if command -v xclip > /dev/null
+            echo "$commit_msg" | xclip -selection clipboard
+            echo "AI Commit message copied to clipboard!"
+            echo "Use 'c' in lazygit to paste and commit."
+        else
+            echo "No clipboard utility (wl-copy or xclip) found."
+            echo "Generated message: $commit_msg"
+        end
+        return 0
+    end
 
     # Display and Confirm
     echo "--------------------------------------------------"

--- a/.config/fish/functions/dot-commit-ai.fish
+++ b/.config/fish/functions/dot-commit-ai.fish
@@ -49,10 +49,10 @@ function dot-commit-ai
     if test $copy_to_clipboard -eq 1
         set -l copied 0
         if command -v wl-copy > /dev/null
-            echo "$commit_msg" | wl-copy
+            echo "$commit_msg" | wl-copy >/dev/null 2>&1
             set copied 1
         else if command -v xclip > /dev/null
-            echo "$commit_msg" | xclip -selection clipboard
+            echo "$commit_msg" | xclip -selection clipboard >/dev/null 2>&1
             set copied 1
         end
 

--- a/.config/fish/functions/dot-commit-ai.fish
+++ b/.config/fish/functions/dot-commit-ai.fish
@@ -3,10 +3,9 @@ function dot-commit-ai
     set -l diff_content ""
     set -l copy_to_clipboard 0
 
-    for arg in $argv
-        if test "$arg" = "--clipboard"
-            set copy_to_clipboard 1
-        end
+    argparse --name=dot-commit-ai 'clipboard' -- $argv
+    if set -q _flag_clipboard
+        set copy_to_clipboard 1
     end
 
     # Check if there are staged changes

--- a/.config/fish/functions/dot-commit-ai.fish
+++ b/.config/fish/functions/dot-commit-ai.fish
@@ -47,12 +47,16 @@ function dot-commit-ai
     set commit_msg (string trim $commit_msg)
 
     if test $copy_to_clipboard -eq 1
+        set -l copied 0
         if command -v wl-copy > /dev/null
             echo "$commit_msg" | wl-copy
-            echo "AI Commit message copied to clipboard!"
-            echo "Use 'c' in lazygit to paste and commit."
+            set copied 1
         else if command -v xclip > /dev/null
             echo "$commit_msg" | xclip -selection clipboard
+            set copied 1
+        end
+
+        if test $copied -eq 1
             echo "AI Commit message copied to clipboard!"
             echo "Use 'c' in lazygit to paste and commit."
         else

--- a/.config/fish/functions/dot-lazy.fish
+++ b/.config/fish/functions/dot-lazy.fish
@@ -1,7 +1,7 @@
 function dot-lazy --description 'Lazygit wrapper for dotfiles'
     # Default to $HOME/.cfg if not set
     set -q DOTFILES_DIR; or set -Ux DOTFILES_DIR $HOME/.dotfiles.git
-    set lazy_config (realpath (path join (status dirname) "dot-lazy.yml"))
+    set lazy_config (realpath (string join (status dirname) 'dot-lazy.yml'))
 
     lazygit --git-dir=$DOTFILES_DIR --work-tree=$HOME $argv -ucf $lazy_config
 end

--- a/.config/fish/functions/dot-lazy.fish
+++ b/.config/fish/functions/dot-lazy.fish
@@ -1,7 +1,7 @@
 function dot-lazy --description 'Lazygit wrapper for dotfiles'
     # Default to $HOME/.cfg if not set
     set -q DOTFILES_DIR; or set -Ux DOTFILES_DIR $HOME/.dotfiles.git
-    set lazy_config (realpath (status dirname)"/dot-lazy.yml")
+    set lazy_config (realpath (path join (status dirname) "dot-lazy.yml"))
 
     lazygit --git-dir=$DOTFILES_DIR --work-tree=$HOME $argv -ucf $lazy_config
 end

--- a/.config/fish/functions/dot-lazy.fish
+++ b/.config/fish/functions/dot-lazy.fish
@@ -1,7 +1,7 @@
 function dot-lazy --description 'Lazygit wrapper for dotfiles'
     # Default to $HOME/.cfg if not set
     set -q DOTFILES_DIR; or set -Ux DOTFILES_DIR $HOME/.dotfiles.git
-    set lazy_config (realpath (string join (status dirname) 'dot-lazy.yml'))
+    set lazy_config (realpath (status dirname)"/dot-lazy.yml")
 
     lazygit --git-dir=$DOTFILES_DIR --work-tree=$HOME $argv -ucf $lazy_config
 end

--- a/.config/fish/functions/dot-lazy.fish
+++ b/.config/fish/functions/dot-lazy.fish
@@ -1,7 +1,7 @@
 function dot-lazy --description 'Lazygit wrapper for dotfiles'
     # Default to $HOME/.cfg if not set
     set -q DOTFILES_DIR; or set -Ux DOTFILES_DIR $HOME/.dotfiles.git
-    set lazy_config (realpath (string join (status dirname) 'dot-lazy.yml'))
+    set lazy_config "$HOME/.config/fish/functions/dot-lazy.yml"
 
     lazygit --git-dir=$DOTFILES_DIR --work-tree=$HOME $argv -ucf $lazy_config
 end

--- a/.config/fish/functions/dot-lazy.yml
+++ b/.config/fish/functions/dot-lazy.yml
@@ -4,4 +4,4 @@ customCommands:
     context: 'global'
     loadingText: "Generate commit message..."
     description: "generate commit message using Gemini and copy to clipboard"
-    showOutput: true
+    output: "log"

--- a/.config/fish/functions/dot-lazy.yml
+++ b/.config/fish/functions/dot-lazy.yml
@@ -1,7 +1,7 @@
 customCommands:
   - key: 'I'
-    command: "dot-commit-ai"
+    command: "dot-commit-ai --clipboard"
     context: 'global'
     loadingText: "Generate commit message..."
-    description: "generate commit message using Gemini"
-    output: "terminal"
+    description: "generate commit message using Gemini and copy to clipboard"
+    showOutput: true

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -60,7 +60,7 @@ repo_root/
     - **Automatic Filtering**: Always excludes files already tracked by the Git repository.
     - Updates `.gitignore` to whitelist the files using root-anchored paths (`!/filename`).
     - Stages the target files and the updated `.gitignore` in the Git repository.
-- **`dot-commit-ai`**: Generates conventional commit messages using Gemini Flash. Falls back to unstaged changes if the staging area is empty.
+- **`dot-commit-ai`**: Generates conventional commit messages using Gemini Flash. Falls back to unstaged changes if the staging area is empty. Includes a `--clipboard` mode for seamless integration within the `dot-lazy` UI without breaking context.
 - **`dot-ai`**: Generates or modifies dotfiles using Gemini Pro.
     - **Context Awareness**: Scans the repository structure and reads content of relevant tracked files to understand the user's specific configuration style before making suggestions.
     - **Safety**: Outputs JSON to avoid parsing errors and asks for user confirmation before applying changes.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The following universal variables can be used to customize the behavior of the t
   - Automatically updates `.gitignore` (un-ignores the file using root-anchored paths) and stages the changes.
 - **Commit changes**: Run `dot-lazy` (or `dot commit ...`).
 - **AI Features**:
-  - `dot-commit-ai`: Automatically generates a conventional commit message. Supports generating for unstaged changes (via `commit -a`) if no staged changes exist.
+  - `dot-commit-ai`: Automatically generates a conventional commit message. Supports generating for unstaged changes (via `commit -a`) if no staged changes exist. Can be triggered directly within `dot-lazy` (via the `I` shortcut) to copy the message to the clipboard seamlessly.
   - `dot-ai "prompt"`: Asks Gemini to generate or modify dotfiles based on your prompt (e.g., `dot-ai "alias for ls -la"`).
 
 ### AI Integration (Gemini)

--- a/setup.fish
+++ b/setup.fish
@@ -36,6 +36,7 @@ end
 set managed_tools \
     ".config/fish/functions/dot.fish" \
     ".config/fish/functions/dot-lazy.fish" \
+    ".config/fish/functions/dot-lazy.yml" \
     ".config/fish/functions/dot-add.fish" \
     ".config/fish/functions/_dot_add_helper.fish" \
     ".config/fish/functions/_dot_gemini_api.fish" \

--- a/setup.fish
+++ b/setup.fish
@@ -27,7 +27,6 @@ set RAW_BASE_URL "https://raw.githubusercontent.com/$REPO_USER/$REPO_NAME/$REPO_
 if test "$REPO_BRANCH" != "main"
     set_color red
     echo "WARNING: You are on a development branch ($REPO_BRANCH)."
-    echo "Do not merge to main without reverting REPO_BRANCH to 'main'."
     set_color normal
     sleep 2
 end


### PR DESCRIPTION
Fixes the string join behavior in \`dot-lazy.fish\` which caused a file not found error, and adds \`dot-lazy.yml\` to the managed tools list in \`setup.fish\`.